### PR TITLE
Implement saving in setting_history rows deleted from the setting table

### DIFF
--- a/migrations/versions/2022_09_19_2217-274098d8e256_refactoring_db_tables.py
+++ b/migrations/versions/2022_09_19_2217-274098d8e256_refactoring_db_tables.py
@@ -1,0 +1,171 @@
+"""refactoring db tables
+
+Revision ID: 274098d8e256
+Revises: 576f9300dac3
+Create Date: 2022-09-19 22:17:02.232745
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '274098d8e256'
+down_revision = '576f9300dac3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'setting_history', sa.Column('is_deleted', sa.Boolean(), server_default=sa.text('false'), nullable=False)
+    )
+    op.add_column('setting_history', sa.Column('deleted_by_db_user', sa.Text(), nullable=True))
+
+    op.drop_column('setting_history', 'setting_id')
+
+    op.alter_column('setting', column_name='user_name', new_column_name='created_by_db_user')
+    op.alter_column('setting_history', column_name='user_name', new_column_name='created_by_db_user')
+
+    op.execute('DROP TRIGGER trigger_create_history_entry_for_setting ON setting;')
+    op.execute('DROP FUNCTION create_history_entry_for_setting;')
+    op.execute(upgrade_trigger_create_history_entry_for_setting)
+
+    op.execute('DROP TRIGGER trigger_fill_user_in_setting_row ON setting;')
+    op.execute('DROP FUNCTION fill_user_in_setting_row;')
+    op.execute(upgrade_trigger_fill_user_in_setting_row)
+
+
+def downgrade() -> None:
+    op.drop_column('setting_history', 'deleted_by_db_user')
+    op.drop_column('setting_history', 'is_deleted')
+
+    op.add_column('setting_history', sa.Column('setting_id', sa.INTEGER(), autoincrement=False, nullable=True))
+
+    op.alter_column('setting', column_name='created_by_db_user', new_column_name='user_name')
+    op.alter_column('setting_history', column_name='created_by_db_user', new_column_name='user_name')
+
+    op.execute('DROP TRIGGER trigger_create_history_entry_for_setting ON setting;')
+    op.execute('DROP FUNCTION create_history_entry_for_setting;')
+    op.execute(downgrade_trigger_create_history_entry_for_setting)
+
+    op.execute('DROP TRIGGER trigger_fill_user_in_setting_row ON setting;')
+    op.execute('DROP FUNCTION fill_user_in_setting_row;')
+    op.execute(downgrade_trigger_fill_user_in_setting_row)
+
+
+upgrade_trigger_create_history_entry_for_setting = """
+    CREATE FUNCTION create_history_entry_for_setting() RETURNS trigger AS
+    $$
+    BEGIN
+        IF TG_OP = 'UPDATE' THEN
+            INSERT INTO setting_history (
+                     name,
+                     value,
+                     value_type,
+                     disable,
+                     service_name,
+                     created_by_db_user,
+                     updated_at
+            )
+            VALUES (
+                    OLD.name,
+                    OLD.value,
+                    OLD.value_type,
+                    OLD.disable,
+                    OLD.service_name,
+                    OLD.created_by_db_user,
+                    OLD.updated_at
+            );
+        ELSIF TG_OP = 'DELETE' THEN
+            INSERT INTO setting_history (
+                     name,
+                     value,
+                     value_type,
+                     disable,
+                     service_name,
+                     created_by_db_user,
+                     updated_at,
+                     is_deleted,
+                     deleted_by_db_user
+            )
+            VALUES (
+                    OLD.name,
+                    OLD.value,
+                    OLD.value_type,
+                    OLD.disable,
+                    OLD.service_name,
+                    OLD.created_by_db_user,
+                    OLD.updated_at,
+                    true,
+                    session_user
+            );
+        END IF;
+        RETURN NEW;
+    END;
+    $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
+
+    CREATE TRIGGER trigger_create_history_entry_for_setting
+        AFTER INSERT OR UPDATE OR DELETE
+        ON setting
+        FOR EACH ROW
+    EXECUTE PROCEDURE create_history_entry_for_setting();
+"""  # noqa=E501
+
+upgrade_trigger_fill_user_in_setting_row = """
+    CREATE FUNCTION fill_user_in_setting_row() RETURNS trigger AS
+    $$
+    BEGIN
+        IF TG_OP IN ('INSERT', 'UPDATE') THEN
+            NEW.created_by_db_user = session_user;
+            NEW.updated_at = current_timestamp;
+        END IF;
+        RETURN NEW;
+    END;
+    $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
+
+    CREATE TRIGGER trigger_fill_user_in_setting_row
+        BEFORE INSERT OR UPDATE
+        ON setting
+        FOR EACH ROW
+    EXECUTE PROCEDURE fill_user_in_setting_row();
+"""
+
+downgrade_trigger_create_history_entry_for_setting = """
+    CREATE FUNCTION create_history_entry_for_setting() RETURNS trigger AS
+    $$
+    BEGIN
+        IF TG_OP = 'UPDATE'
+        THEN
+            INSERT INTO setting_history (setting_id, name, value, value_type, disable, service_name, user_name, updated_at)
+            VALUES (OLD.id, OLD.name, OLD.value, OLD.value_type, OLD.disable, OLD.service_name, OLD.user_name, OLD.updated_at);
+        END IF;
+        RETURN NEW;
+    END;
+    $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
+
+    CREATE TRIGGER trigger_create_history_entry_for_setting
+        AFTER INSERT OR UPDATE
+        ON setting
+        FOR EACH ROW
+    EXECUTE PROCEDURE create_history_entry_for_setting();
+"""  # noqa=E501
+
+downgrade_trigger_fill_user_in_setting_row = """
+    CREATE FUNCTION fill_user_in_setting_row() RETURNS trigger AS
+    $$
+    BEGIN
+        IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE'
+        THEN
+            NEW.user_name = current_user;
+            NEW.updated_at = current_timestamp;
+            RETURN NEW;
+        END IF;
+    END;
+    $$ LANGUAGE 'plpgsql' SECURITY DEFINER;
+
+    CREATE TRIGGER trigger_fill_user_in_setting_row
+        BEFORE INSERT OR UPDATE
+        ON setting
+        FOR EACH ROW
+    EXECUTE PROCEDURE fill_user_in_setting_row();
+"""

--- a/src/runtime_config/models.py
+++ b/src/runtime_config/models.py
@@ -17,7 +17,7 @@ class Setting(Base):  # type: ignore
     value_type = Column(Enum(ValueType), nullable=False)
     disable = Column(Boolean, server_default=expression.false(), nullable=False)
     service_name = Column(Text, nullable=False)
-    user_name = Column(Text)
+    created_by_db_user = Column(Text)
     updated_at = Column(DateTime, nullable=False)
 
     __table_args__ = (UniqueConstraint('name', 'service_name', name='unique_setting_name_per_service'),)
@@ -27,11 +27,12 @@ class SettingHistory(Base):  # type: ignore
     __tablename__ = 'setting_history'
 
     id = Column(Integer, primary_key=True)
-    setting_id = Column(Integer)
     name = Column(Text, nullable=False)
     value = Column(Text)
     value_type = Column(Enum(ValueType), nullable=False)
     disable = Column(Boolean, nullable=False)
     service_name = Column(Text, nullable=False)
-    user_name = Column(Text, nullable=False)
+    created_by_db_user = Column(Text, nullable=False)
     updated_at = Column(DateTime, nullable=False)
+    is_deleted = Column(Boolean, server_default=expression.false(), nullable=False)
+    deleted_by_db_user = Column(Text)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -13,5 +13,5 @@ def setting_data_fixture(config):
         'value_type': ValueType.int,
         'disable': False,
         'service_name': 'service-name',
-        'user_name': config.db_user,
+        'created_by_db_user': config.db_user,
     }


### PR DESCRIPTION
- removed setting_id column from setting_history table
- renamed user_name column to created_by_db_user
- fixed problem with determining the name of the user who makes changes